### PR TITLE
Fix GetNameClassWriter errors during remap on JDK11 classes

### DIFF
--- a/jarjar-core/src/main/java/com/tonicsystems/jarjar/strings/StringReader.java
+++ b/jarjar-core/src/main/java/com/tonicsystems/jarjar/strings/StringReader.java
@@ -31,7 +31,7 @@ public abstract class StringReader extends ClassVisitor {
     private String className;
 
     public StringReader() {
-        super(Opcodes.ASM5);
+        super(Opcodes.ASM8);
     }
 
     public abstract void visitString(@Nonnull String className, @Nonnull String value, @Nonnegative int line);
@@ -50,7 +50,7 @@ public abstract class StringReader extends ClassVisitor {
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
         handleObject(value);
-        return new FieldVisitor(Opcodes.ASM5) {
+        return new FieldVisitor(Opcodes.ASM8) {
             @Override
             public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
                 return StringReader.this.visitAnnotation(desc, visible);
@@ -60,7 +60,7 @@ public abstract class StringReader extends ClassVisitor {
 
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        return new AnnotationVisitor(Opcodes.ASM5) {
+        return new AnnotationVisitor(Opcodes.ASM8) {
             @Override
             public void visit(String name, Object value) {
                 handleObject(value);
@@ -81,7 +81,7 @@ public abstract class StringReader extends ClassVisitor {
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc,
             String signature, String[] exceptions) {
-        return new MethodVisitor(Opcodes.ASM5) {
+        return new MethodVisitor(Opcodes.ASM8) {
             @Override
             public void visitLdcInsn(Object cst) {
                 handleObject(cst);

--- a/jarjar-core/src/main/java/com/tonicsystems/jarjar/transform/asm/GetNameClassWriter.java
+++ b/jarjar-core/src/main/java/com/tonicsystems/jarjar/transform/asm/GetNameClassWriter.java
@@ -28,7 +28,7 @@ public class GetNameClassWriter extends ClassVisitor {
      */
      // * @param flags may include {@link ClassWriter#COMPUTE_FRAMES} * or {@link ClassWriter#COMPUTE_MAXS}.
     public GetNameClassWriter(ClassVisitor cv) {
-        super(Opcodes.ASM5, cv);
+        super(Opcodes.ASM8, cv);
     }
 
     @Override


### PR DESCRIPTION
Although the remap process for ASM8 supports higher JDKs, remapping fails on some classes because GetNameClassWriter (which only gets the class name) was throwing an error when processing JDK11 classes with newer features like those from org.jgroups:jgroups.

Example errors:
```
2021/05/27 04:24:11 WARN ClassTransformerJarProcessor[main]: Failed to read class org/jgroups/protocols/Locking.class: java.lang.UnsupportedOperationException: This feature requires ASM7
2021/05/27 04:24:11 WARN ClassTransformerJarProcessor[main]: Failed to read class org/jgroups/protocols/SSL_KEY_EXCHANGE$SessionVerifier.class: java.lang.UnsupportedOperationException: This feature requires ASM7
```
The fix here is to simply change ASM5 to ASM8, the highest stable version / matching version of the current depended-on ASM.

Additionally, we change StringReader to use the higher ASM version as well to prevent errors for the `strings` command, but do not make any specific changes to process/display additional strings for the newer features available since ASM5 in ClassVisitor.